### PR TITLE
feat: add weather endpoint for weekly weather status

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 )
@@ -9,6 +10,18 @@ import (
 type HealthResponse struct {
 	Message string `json:"message"`
 	Status  string `json:"status"`
+}
+
+type WeatherData struct {
+	Time          string  `json:"time"`
+	Temperature2m float64 `json:"temperature_2m"`
+}
+
+type OpenMeteoResponse struct {
+	Hourly struct {
+		Time          []string  `json:"time"`
+		Temperature2m []float64 `json:"temperature_2m"`
+	} `json:"hourly"`
 }
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
@@ -31,8 +44,64 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func weatherHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Fetch data from Open-Meteo API
+	url := "https://api.open-meteo.com/v1/forecast?latitude=41.05&longitude=28.72&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Printf("Error fetching weather data: %v", err)
+		http.Error(w, "Failed to fetch weather data", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("Open-Meteo API returned status: %d", resp.StatusCode)
+		http.Error(w, "Weather service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading response body: %v", err)
+		http.Error(w, "Failed to read weather data", http.StatusInternalServerError)
+		return
+	}
+
+	var openMeteoResp OpenMeteoResponse
+	if err := json.Unmarshal(body, &openMeteoResp); err != nil {
+		log.Printf("Error parsing weather data: %v", err)
+		http.Error(w, "Failed to parse weather data", http.StatusInternalServerError)
+		return
+	}
+
+	// Transform data into required format
+	var weatherData []WeatherData
+	for i := 0; i < len(openMeteoResp.Hourly.Time) && i < len(openMeteoResp.Hourly.Temperature2m); i++ {
+		weatherData = append(weatherData, WeatherData{
+			Time:          openMeteoResp.Hourly.Time[i],
+			Temperature2m: openMeteoResp.Hourly.Temperature2m[i],
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(weatherData); err != nil {
+		log.Printf("Error encoding weather response: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
 func main() {
 	http.HandleFunc("/api/health", helloHandler)
+	http.HandleFunc("/api/weather", weatherHandler)
 
 	port := ":8080"
 	log.Printf("Server starting on port %s", port)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWeatherHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api/weather", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(weatherHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var weatherData []WeatherData
+	if err := json.Unmarshal(rr.Body.Bytes(), &weatherData); err != nil {
+		t.Errorf("Failed to parse response JSON: %v", err)
+	}
+
+	if len(weatherData) == 0 {
+		t.Error("Expected non-empty weather data")
+	}
+
+	for _, data := range weatherData {
+		if data.Time == "" {
+			t.Error("Expected non-empty time field")
+		}
+	}
+}
+
+func TestHelloHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(helloHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response HealthResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Errorf("Failed to parse response JSON: %v", err)
+	}
+
+	if response.Message != "Hello World!" {
+		t.Errorf("Expected message 'Hello World!', got %v", response.Message)
+	}
+
+	if response.Status != "success" {
+		t.Errorf("Expected status 'success', got %v", response.Status)
+	}
+}


### PR DESCRIPTION
- Creates /api/weather endpoint that fetches data from Open-Meteo API
- Transforms hourly weather data to extract time and temperature_2m fields
- Returns array of objects with time and temperature_2m properties
- Includes comprehensive error handling and logging
- Adds unit tests for both weather and health endpoints

Closes #1

Generated with [Claude Code](https://claude.ai/code)